### PR TITLE
feat: add array fields types in the `is` builder

### DIFF
--- a/src/schema/arrayField.test.ts
+++ b/src/schema/arrayField.test.ts
@@ -1,0 +1,316 @@
+import { addStringNoLocale, getStringNoLocaleAll } from "@inrupt/solid-client";
+import { createThing, hasExactly } from "../ldutils.test";
+import { Maybe } from "../types";
+import { ArrayBuilder, ArrayField } from "./arrayField";
+
+const url = "http://an.entity#one";
+const predicate1 = "http://predicate.one";
+const predicate2 = "http://predicate.two";
+
+describe("the `ArrayField` class", () => {
+  it("can write data to a thing", () => {
+    const field = new ArrayField<string>({
+      getter: getStringNoLocaleAll,
+      setter: addStringNoLocale,
+      predicates: [predicate1],
+    });
+
+    const thing = field.write(createThing(url), [
+      "element one",
+      "element two",
+      "element three",
+    ]);
+
+    expect(
+      hasExactly(
+        thing,
+        [url, predicate1, "element one"],
+        [url, predicate1, "element two"],
+        [url, predicate1, "element three"]
+      )
+    ).toEqual(true);
+  });
+
+  it("overrides data on a thing", () => {
+    const field = new ArrayField<string>({
+      getter: getStringNoLocaleAll,
+      setter: addStringNoLocale,
+      predicates: [predicate1],
+    });
+
+    const thing = field.write(
+      createThing(
+        url,
+        [url, predicate1, "element four"],
+        [url, predicate1, "element five"]
+      ),
+      ["element one", "element two", "element three"]
+    );
+
+    expect(
+      hasExactly(
+        thing,
+        [url, predicate1, "element one"],
+        [url, predicate1, "element two"],
+        [url, predicate1, "element three"]
+      )
+    ).toEqual(true);
+  });
+
+  it("can write data with multiple predicates", () => {
+    const field = new ArrayField<string>({
+      getter: getStringNoLocaleAll,
+      setter: addStringNoLocale,
+      predicates: [predicate1, predicate2],
+    });
+
+    const thing = field.write(createThing(url), [
+      "element one",
+      "element two",
+      "element three",
+    ]);
+
+    expect(
+      hasExactly(
+        thing,
+        [url, predicate1, "element one"],
+        [url, predicate1, "element two"],
+        [url, predicate1, "element three"],
+        [url, predicate2, "element one"],
+        [url, predicate2, "element two"],
+        [url, predicate2, "element three"]
+      )
+    ).toEqual(true);
+  });
+
+  it("correctly removes all values if setting an empty array, null or undefined", () => {
+    const field = new ArrayField<string>({
+      getter: getStringNoLocaleAll,
+      setter: addStringNoLocale,
+      predicates: [predicate1],
+    });
+
+    let thing = field.write(
+      createThing(
+        url,
+        [url, predicate1, "element one"],
+        [url, predicate1, "element two"],
+        [url, predicate1, "element three"]
+      ),
+      []
+    );
+
+    expect(thing.size).toEqual(0);
+
+    thing = field.write(
+      createThing(
+        url,
+        [url, predicate1, "element one"],
+        [url, predicate1, "element two"],
+        [url, predicate1, "element three"]
+      ),
+      null
+    );
+
+    expect(thing.size).toEqual(0);
+
+    thing = field.write(
+      createThing(
+        url,
+        [url, predicate1, "element one"],
+        [url, predicate1, "element two"],
+        [url, predicate1, "element three"]
+      ),
+      undefined
+    );
+
+    expect(thing.size).toEqual(0);
+  });
+
+  it("write the default value if set and value to write is null or undefined", () => {
+    const field = new ArrayField<string>({
+      getter: getStringNoLocaleAll,
+      setter: addStringNoLocale,
+      predicates: [predicate1],
+      default: ["one", "two"],
+    });
+
+    expect(
+      hasExactly(
+        field.write(createThing(url), []),
+        [url, predicate1, "one"],
+        [url, predicate1, "two"]
+      )
+    ).toEqual(true);
+
+    expect(
+      hasExactly(
+        field.write(createThing(url), null),
+        [url, predicate1, "one"],
+        [url, predicate1, "two"]
+      )
+    ).toEqual(true);
+
+    expect(
+      hasExactly(
+        field.write(createThing(url), undefined),
+        [url, predicate1, "one"],
+        [url, predicate1, "two"]
+      )
+    ).toEqual(true);
+  });
+
+  it("use the given serialize function when writing data", () => {
+    const field = new ArrayField<string>({
+      getter: getStringNoLocaleAll,
+      setter: addStringNoLocale,
+      predicates: [predicate1],
+      serialize: (values) => values?.map((v) => "__" + v),
+    });
+
+    expect(
+      hasExactly(
+        field.write(createThing(url), ["one", "two"]),
+        [url, predicate1, "__one"],
+        [url, predicate1, "__two"]
+      )
+    ).toEqual(true);
+  });
+
+  it("can read data from a thing", () => {
+    const field = new ArrayField<string>({
+      getter: getStringNoLocaleAll,
+      setter: addStringNoLocale,
+      predicates: [predicate1],
+    });
+
+    const thing = createThing(
+      url,
+      [url, predicate1, "element one"],
+      [url, predicate1, "element two"],
+      [url, predicate1, "element three"]
+    );
+
+    expect(field.read(thing)).toEqual([
+      "element one",
+      "element two",
+      "element three",
+    ]);
+  });
+
+  it("can read data from multiple predicates", () => {
+    const field = new ArrayField<string>({
+      getter: getStringNoLocaleAll,
+      setter: addStringNoLocale,
+      predicates: [predicate1, predicate2],
+    });
+
+    const thing = createThing(
+      url,
+      [url, predicate2, "element one"],
+      [url, predicate2, "element two"],
+      [url, predicate2, "element three"]
+    );
+
+    expect(field.read(thing)).toEqual([
+      "element one",
+      "element two",
+      "element three",
+    ]);
+  });
+
+  it("read the default value if predicate does not exist", () => {
+    const field = new ArrayField<string>({
+      getter: getStringNoLocaleAll,
+      setter: addStringNoLocale,
+      predicates: [predicate1],
+      default: ["one", "two"],
+    });
+
+    const thing = createThing(url);
+
+    expect(field.read(thing)).toEqual(["one", "two"]);
+  });
+
+  it("use the given deserialize function when reading data", () => {
+    const field = new ArrayField<string>({
+      getter: getStringNoLocaleAll,
+      setter: addStringNoLocale,
+      predicates: [predicate1],
+      deserialize: (values) => values?.map((v) => v + "__"),
+    });
+
+    const thing = createThing(
+      url,
+      [url, predicate1, "element one"],
+      [url, predicate1, "element two"],
+      [url, predicate1, "element three"]
+    );
+
+    expect(field.read(thing)).toEqual([
+      "element one__",
+      "element two__",
+      "element three__",
+    ]);
+  });
+});
+
+describe("the `ArrayBuilder` class", () => {
+  it("can build a simple ArrayField", () => {
+    const field = new ArrayBuilder({
+      getter: getStringNoLocaleAll,
+      setter: addStringNoLocale,
+      predicates: [predicate1],
+    }).build();
+    expect(field).toEqual(
+      new ArrayField<string>({
+        getter: getStringNoLocaleAll,
+        setter: addStringNoLocale,
+        predicates: [predicate1],
+      })
+    );
+    expect(field).toBeInstanceOf(ArrayField);
+  });
+
+  it("can build an ArrayField with a default value", () => {
+    const field = new ArrayBuilder({
+      getter: getStringNoLocaleAll,
+      setter: addStringNoLocale,
+      predicates: [predicate1],
+    })
+      .default(["one", "two"])
+      .build();
+    expect(field).toEqual(
+      new ArrayField<string>({
+        getter: getStringNoLocaleAll,
+        setter: addStringNoLocale,
+        predicates: [predicate1],
+        default: ["one", "two"],
+      })
+    );
+    expect(field).toBeInstanceOf(ArrayField);
+  });
+
+  it("can build an ArrayField with a converter", () => {
+    const serialize = (values: Maybe<string[]>) => values?.map((v) => v + "__");
+    const deserialize = (values: Maybe<string[]>) =>
+      values?.map((v) => v.substr(values.length - 2));
+    const field = new ArrayBuilder({
+      getter: getStringNoLocaleAll,
+      setter: addStringNoLocale,
+      predicates: [predicate1],
+    })
+      .converter(serialize, deserialize)
+      .build();
+    expect(field).toEqual(
+      new ArrayField<string>({
+        getter: getStringNoLocaleAll,
+        setter: addStringNoLocale,
+        predicates: [predicate1],
+        serialize,
+        deserialize,
+      })
+    );
+    expect(field).toBeInstanceOf(ArrayField);
+  });
+});

--- a/src/schema/arrayField.ts
+++ b/src/schema/arrayField.ts
@@ -1,0 +1,85 @@
+import { removeAll, Thing } from "@inrupt/solid-client";
+import { Maybe } from "../types";
+import { PrimitiveFieldOptions } from "./primitiveField";
+import { Builder, Field } from "./schema";
+
+/**
+ * Options available to customize a field containing an array of values.
+ */
+export type ArrayFieldOptions<TPrimitive> = PrimitiveFieldOptions<TPrimitive[]>;
+
+/**
+ * Array field used to read and write array of values to and from a Thing.
+ */
+export class ArrayField<TPrimitive> implements Field<TPrimitive[]> {
+  constructor(private readonly options: ArrayFieldOptions<TPrimitive>) {}
+
+  read(thing: Thing): Maybe<TPrimitive[]> {
+    let val: Maybe<TPrimitive[]> = null;
+
+    for (const predicate of this.options.predicates) {
+      val = this.options.getter(thing, predicate);
+      if (val && val?.length > 0) {
+        break;
+      }
+    }
+
+    val = this.useDefaultValueIfEmpty(val);
+
+    return this.options.deserialize ? this.options.deserialize(val) : val;
+  }
+
+  write(thing: Thing, value: Maybe<TPrimitive[]>): Thing {
+    let valueToWrite: Maybe<TPrimitive[]> = this.useDefaultValueIfEmpty(value);
+
+    if (this.options.serialize) {
+      valueToWrite = this.options.serialize(valueToWrite);
+    }
+
+    return this.options.predicates.reduce(
+      (curThing, predicate) =>
+        (valueToWrite ?? []).reduce(
+          (thing, value) => this.options.setter(thing, predicate, value),
+          removeAll(curThing, predicate)
+        ),
+      thing
+    );
+  }
+
+  private useDefaultValueIfEmpty(
+    value: Maybe<TPrimitive[]>
+  ): Maybe<TPrimitive[]> {
+    return (value == null || value.length === 0) && this.options.default
+      ? this.options.default
+      : value;
+  }
+}
+
+/**
+ * Array field builder.
+ */
+export class ArrayBuilder<TPrimitive> implements Builder<TPrimitive[]> {
+  constructor(private readonly options: ArrayFieldOptions<TPrimitive>) {}
+
+  /**
+   * Sets a default value used when reading and writing this field.
+   */
+  default(value: TPrimitive[]): ArrayBuilder<TPrimitive> {
+    return new ArrayBuilder({ ...this.options, default: value });
+  }
+
+  /**
+   * Register methods to be called when writing this field to a Thing and reading from
+   * a Thing. It enables you to process a value as its being write / read.
+   */
+  converter(
+    serialize: (localValue?: Maybe<TPrimitive[]>) => Maybe<TPrimitive[]>,
+    deserialize: (persistedValue: Maybe<TPrimitive[]>) => Maybe<TPrimitive[]>
+  ): ArrayBuilder<TPrimitive> {
+    return new ArrayBuilder({ ...this.options, serialize, deserialize });
+  }
+
+  build(): Field<TPrimitive[]> {
+    return new ArrayField<TPrimitive>(this.options);
+  }
+}

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -13,3 +13,4 @@ export {
   PrimitiveBuilder,
   PrimitiveFieldOptions,
 } from "./primitiveField";
+export { ArrayField, ArrayBuilder, ArrayFieldOptions } from "./arrayField";

--- a/src/schema/schema.test.ts
+++ b/src/schema/schema.test.ts
@@ -9,6 +9,12 @@ const predicate3 = "http://predicate.three";
 const predicate4 = "http://predicate.four";
 const predicate5 = "http://predicate.five";
 const predicate6 = "http://predicate.six";
+const predicate7 = "http://predicate.seven";
+const predicate8 = "http://predicate.eight";
+const predicate9 = "http://predicate.nine";
+const predicate10 = "http://predicate.ten";
+const predicate11 = "http://predicate.eleven";
+const predicate12 = "http://predicate.twelve";
 
 describe("the `Schema` class", () => {
   it("needs a KeyField definition", () => {
@@ -75,6 +81,15 @@ describe("the `Schema` class", () => {
       anInteger: 42,
       aDecimal: 133.7,
       aDate: new Date("2020-05-04T13:37:42.000Z"),
+      someStrings: ["one", "two"],
+      someBooleans: [true, false],
+      someUrls: ["https://some.website1.url", "https://some.website2.url"],
+      someIntegers: [1, 2],
+      someDecimals: [1.2, 3.4],
+      someDates: [
+        new Date("2020-06-04T13:37:42.000Z"),
+        new Date("2020-07-04T13:37:42.000Z"),
+      ],
     };
     const schema = new Schema<typeof data>(predicate1, {
       id: is.key().base64(),
@@ -84,6 +99,12 @@ describe("the `Schema` class", () => {
       anInteger: is.integer(predicate4),
       aDecimal: is.decimal(predicate5),
       aDate: is.datetime(predicate6),
+      someStrings: is.strings(predicate7),
+      someBooleans: is.booleans(predicate8),
+      someUrls: is.urls(predicate9),
+      someIntegers: is.integers(predicate10),
+      someDecimals: is.decimals(predicate11),
+      someDates: is.datetimes(predicate12),
     });
 
     const thing = schema.write(createThing({ url }), data);
@@ -97,7 +118,19 @@ describe("the `Schema` class", () => {
         [url, predicate3, data.anUrl],
         [url, predicate4, data.anInteger],
         [url, predicate5, data.aDecimal],
-        [url, predicate6, data.aDate]
+        [url, predicate6, data.aDate],
+        [url, predicate7, data.someStrings[0]],
+        [url, predicate7, data.someStrings[1]],
+        [url, predicate8, data.someBooleans[0]],
+        [url, predicate8, data.someBooleans[1]],
+        [url, predicate9, data.someUrls[0]],
+        [url, predicate9, data.someUrls[1]],
+        [url, predicate10, data.someIntegers[0]],
+        [url, predicate10, data.someIntegers[1]],
+        [url, predicate11, data.someDecimals[0]],
+        [url, predicate11, data.someDecimals[1]],
+        [url, predicate12, data.someDates[0]],
+        [url, predicate12, data.someDates[1]]
       )
     ).toEqual(true);
   });
@@ -111,6 +144,15 @@ describe("the `Schema` class", () => {
       anInteger: 42,
       aDecimal: 133.7,
       aDate: new Date("2020-05-04T13:37:42Z"),
+      someStrings: ["one", "two"],
+      someBooleans: [true, false],
+      someUrls: ["https://some.website1.url", "https://some.website2.url"],
+      someIntegers: [1, 2],
+      someDecimals: [1.2, 3.4],
+      someDates: [
+        new Date("2020-06-04T13:37:42.000Z"),
+        new Date("2020-07-04T13:37:42.000Z"),
+      ],
     };
     const schema = new Schema<typeof data>(predicate1, {
       id: is.key().base64(),
@@ -120,6 +162,12 @@ describe("the `Schema` class", () => {
       anInteger: is.integer(predicate4),
       aDecimal: is.decimal(predicate5),
       aDate: is.datetime(predicate6),
+      someStrings: is.strings(predicate7),
+      someBooleans: is.booleans(predicate8),
+      someUrls: is.urls(predicate9),
+      someIntegers: is.integers(predicate10),
+      someDecimals: is.decimals(predicate11),
+      someDates: is.datetimes(predicate12),
     });
     const thing = schema.write(createThing({ url }), data);
 

--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -12,9 +12,22 @@ import {
   setDecimal,
   getInteger,
   setInteger,
+  getStringNoLocaleAll,
+  addStringNoLocale,
+  addBoolean,
+  getBooleanAll,
+  getUrlAll,
+  addUrl,
+  getDatetimeAll,
+  addDatetime,
+  getDecimalAll,
+  addDecimal,
+  getIntegerAll,
+  addInteger,
 } from "@inrupt/solid-client";
 import { KeyField, KeyBuilder } from "./keyField";
 import { PrimitiveBuilder } from "./primitiveField";
+import { ArrayBuilder } from "./arrayField";
 import { Maybe } from "../types";
 import { rdf } from "../namespaces";
 
@@ -75,8 +88,6 @@ export class NoKeyDefined extends Error {
  * The `is` object enables you to define a schema using predicates for a javascript
  * object type. It makes really convenient to build a schema definition with an easy
  * to read fluent API.
- *
- * TODO: Manage array of those primitives and nested properties in the long run...
  */
 export const is = {
   key: (): KeyBuilder => new KeyBuilder(),
@@ -86,10 +97,22 @@ export const is = {
       setter: setStringNoLocale,
       predicates,
     }),
+  strings: (...predicates: string[]): ArrayBuilder<string> =>
+    new ArrayBuilder({
+      getter: getStringNoLocaleAll,
+      setter: addStringNoLocale,
+      predicates,
+    }),
   boolean: (...predicates: string[]): PrimitiveBuilder<boolean> =>
     new PrimitiveBuilder({
       getter: getBoolean,
       setter: setBoolean,
+      predicates,
+    }),
+  booleans: (...predicates: string[]): ArrayBuilder<boolean> =>
+    new ArrayBuilder({
+      getter: getBooleanAll,
+      setter: addBoolean,
       predicates,
     }),
   url: (...predicates: string[]): PrimitiveBuilder<string> =>
@@ -98,10 +121,22 @@ export const is = {
       setter: setUrl,
       predicates,
     }),
+  urls: (...predicates: string[]): ArrayBuilder<string> =>
+    new ArrayBuilder({
+      getter: getUrlAll,
+      setter: addUrl,
+      predicates,
+    }),
   datetime: (...predicates: string[]): PrimitiveBuilder<Date> =>
     new PrimitiveBuilder({
       getter: getDatetime,
       setter: setDatetime,
+      predicates,
+    }),
+  datetimes: (...predicates: string[]): ArrayBuilder<Date> =>
+    new ArrayBuilder({
+      getter: getDatetimeAll,
+      setter: addDatetime,
       predicates,
     }),
   decimal: (...predicates: string[]): PrimitiveBuilder<number> =>
@@ -110,10 +145,22 @@ export const is = {
       setter: setDecimal,
       predicates,
     }),
+  decimals: (...predicates: string[]): ArrayBuilder<number> =>
+    new ArrayBuilder({
+      getter: getDecimalAll,
+      setter: addDecimal,
+      predicates,
+    }),
   integer: (...predicates: string[]): PrimitiveBuilder<number> =>
     new PrimitiveBuilder({
       getter: getInteger,
       setter: setInteger,
+      predicates,
+    }),
+  integers: (...predicates: string[]): ArrayBuilder<number> =>
+    new ArrayBuilder({
+      getter: getIntegerAll,
+      setter: addInteger,
       predicates,
     }),
 } as const;


### PR DESCRIPTION
Closes #10.

Add plural forms to store array of primitives (`is.strings`, `is.integers` and so on).